### PR TITLE
Add basic Sponsors section

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,6 +3,7 @@
 import Image from "next/image";
 import Faq from "./sections/Faq";
 import About from "./sections/About"
+import Sponsors from "./sections/Sponsors"
 
 // CONSTANTS
 import { useState } from "react";
@@ -171,13 +172,8 @@ export default function Home() {
         {/* FAQ section */}
         <Faq />
 
-        <section id="sponsors">
-          <div className="flex justify-between items-center">
-            <img className="w-1/3" src="./images/sections/dogprints.png"></img>
-            <h1 className="text-4xl md:text-7xl font-display text-section-brown">sponsors</h1>
-            <img className="w-1/3" src="./images/sections/dogprints.png"></img>
-          </div>
-        </section>
+        <Sponsors />
+
         <section id="socials">
           <div className="flex justify-between items-center">
             <img className="w-1/3" src="./images/sections/dogprints.png"></img>

--- a/src/app/sections/Sponsors.tsx
+++ b/src/app/sections/Sponsors.tsx
@@ -1,0 +1,28 @@
+const Sponsors = () => {
+  return (
+    <section
+      id="sponsors"
+      className="flex flex-col items-center text-center justify-center"
+    >
+      <div className="flex justify-between items-center w-full">
+        <img className="w-1/3" src="./images/sections/dogprints.png"></img>
+        <h1 className="text-4xl md:text-7xl font-display text-section-brown">sponsors</h1>
+        <img className="w-1/3" src="./images/sections/dogprints.png"></img>
+      </div>  
+      <div className="font-body text-3xl text-nav-brown w-[72rem]">
+        <p>
+          Sponsorships are what make LazyHacks happen! Sponsors have various opportunities to build meaningful
+          connections with hackers.
+        </p>
+        <p className="mt-8">
+          Interested in sponsoring? Email us at
+          <a href="mailto:sponsor@lazyhacks.ca" className="text-welcome-text hover:text-nav-brown">
+            <span className="font-black"> sponsor@lazyhacks.ca</span>.
+          </a>
+        </p>
+      </div>
+    </section>
+  )
+}
+
+export default Sponsors;


### PR DESCRIPTION
- I'll come back to the email link style
- Open to suggestions for changes to the "Sponsorships are..." text
- The angry sloth image (below) seems kind of random so I didn't add it for now 
![image](https://github.com/user-attachments/assets/b0be4c3c-6dcb-486b-ba13-66b31fbad687)